### PR TITLE
Make sure that https is used

### DIFF
--- a/explorer/secrets.example.py
+++ b/explorer/secrets.example.py
@@ -7,7 +7,7 @@ consumer_key    = ""
 consumer_secret = ""
     
 # The base URL your app is talking to. You won't need to change this.
-server_url = "http://www.khanacademy.org"
+server_url = "https://www.khanacademy.org"
     
 # The secret key used to encrypt your cookies. Generate this randomly by
 # following the directions at:


### PR DESCRIPTION
When trying to access secure resources under the `user` endpoint, there is an error about receiving an invalid signature. That is because Khan Academy is expecting `https` and receiving `http`.

While this will help anyone who is trying to run the program on a local server, to fix current builds the actual secrets.py file will have to be updated.